### PR TITLE
Fix hover for documentation from same file

### DIFF
--- a/src/hover.ts
+++ b/src/hover.ts
@@ -15,7 +15,7 @@ async function provideHover(doc: TextDocument, position: Position): Promise<Hove
 					var externalDoc = await workspace.openTextDocument(item.sourceFilePath);
 					item.documentation = getDocsForLine(externalDoc, externalDoc.lineAt(item.symbol.range.start));
 				} else {
-					item.documentation = getDocsForLine(doc, doc.lineAt(position));
+					item.documentation = getDocsForLine(doc, doc.lineAt(item.symbol.range.start));
 				}
 			}
 


### PR DESCRIPTION
Before this fix, the documentation was shown for the line above the current line. This change will look for the documentation above the actual symbol