### PR TITLE
Fix merge causing includes to no longer work

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -390,15 +390,7 @@ async function provideDocumentSymbols(doc: TextDocument): Promise<DocumentSymbol
 
 		// Clear out the current doc symbols to reload them
 		currentDocSymbols(doc.fileName).clear();
-		const localIncludes = getImportedFiles(doc);
-
-		// Loop through included files FOR THIS DOC and add symbols for them
-		for(const includedFile of localIncludes) {
-			var includedDoc = await workspace.openTextDocument(includedFile[1].Uri);
-
-			getSymbolsForDocument(includedDoc, currentDocSymbols(doc.fileName));
-		}
-
+		
 		// Get the local doc symbols
 		const localSymbols = getSymbolsForDocument(doc, currentDocSymbols(doc.fileName));
 


### PR DESCRIPTION
I was prototyping a bit and noticed includes weren't working anymore. It looks like something broke with merging my changes with @AlmarAubel's changes.

All includes are loaded in line 398 so these lines are not needed anymore. Removing them seems to fix the problem.