### PR TITLE
Fix virtual includes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import signatureProvider from "./signature";
 import definitionProvider from "./definition";
 import colorProvider from "./colorprovider";
 import { IncludeFile, includes } from "./includes";
-import { AspSymbol, VirtualPath } from "./types";
+import { AspSymbol } from "./types";
 import { addRegionHighlights } from "./highlight";
 import { createDocumentSnippet } from "./snippet";
 
@@ -14,8 +14,6 @@ export const output = window.createOutputChannel("ASP Classic");
 
 /** List of all built-in ASP symbols parsed once from source files. */
 export const builtInSymbols = new Set<AspSymbol>();
-
-export const virtualPaths: VirtualPath[] = [];
 
 export function activate(context: ExtensionContext): void {
 
@@ -75,16 +73,6 @@ export function activate(context: ExtensionContext): void {
 		includes.set("ObjectDefs", new IncludeFile(objectIncludesFile));
 
 		addRegionHighlights(context);
-
-		const aspConfig: any = workspace.getConfiguration("asp").get("virtualPaths");
-
-		for (const virtualPath in aspConfig) {
-			if (Object.prototype.hasOwnProperty.call(aspConfig, virtualPath)) {
-				const physicalPath = aspConfig[virtualPath];
-
-				virtualPaths.push({ virtualPath: virtualPath, physicalPath: physicalPath });
-			}
-		}
 
 		context.subscriptions.push(
 			hoverProvider,

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -1,104 +1,114 @@
 import { TextDocument, Uri, workspace } from "vscode";
 import * as pathns from "path";
 import * as fs from "fs";
+import { output } from "./extension";
 
 export class IncludeFile {
-  constructor(path: string) {
-    let path2 = path;
-    if (!pathns.isAbsolute(path2))
-      path2 = pathns.join(workspace.workspaceFolders[0].uri.fsPath, path2);
+	constructor(path: string) {
+		let path2 = path;
+		if (!pathns.isAbsolute(path2))
+			path2 = pathns.join(workspace.workspaceFolders[0].uri.fsPath, path2);
 
-    this.Uri = Uri.file(path2);
+		this.Uri = Uri.file(path2);
 
-    if (fs.existsSync(path2) && fs.statSync(path2).isFile())
-      this.Content = fs.readFileSync(path2).toString();
-  }
+		try {
+			if (fs.existsSync(path2) && fs.statSync(path2).isFile())
+				this.Content = fs.readFileSync(path2).toString();
+		} catch (error) {
+			output.appendLine(`Error: ${error}`);
+		}
+	}
 
-  Content = "";
+	Content = "";
 
-  Uri: Uri;
+	Uri: Uri;
 }
 
 export const includes = new Map<string, IncludeFile>();
 
 /** Matches `<!-- #include file="myfile.asp" --> */
-export const includePattern = /<!--\s*#include\s*file="(.*?)"\s*-->/ig
-export const virtualInclude = /<!--\s*#include\s*virtual="(.*?)"\s*-->/ig
+export const includePattern = /<!--\s*#include\s*file="(.*?)"\s*-->/gi;
+export const virtualInclude = /<!--\s*#include\s*virtual="(.*?)"\s*-->/gi;
 
 /** Gets any included files in the given document. */
-export function getImportedFiles(doc: TextDocument) : [string, IncludeFile][] {
-  const localIncludes = [];
-  const processedMatches = Array<string>();
+export function getImportedFiles(doc: TextDocument): [string, IncludeFile][] {
+	const localIncludes = [];
+	const processedMatches = Array<string>();
 
-  let match : RegExpExecArray;
+	let match: RegExpExecArray;
 
-  // Loop through each included file
-  while ((match = includePattern.exec(doc.getText())) !== null) {
+	// Loop through each included file
+	while ((match = includePattern.exec(doc.getText())) !== null) {
+		if (processedMatches.indexOf(match[1].toLowerCase())) {
+			// Directory for the current doc
+			const currentDirectory = pathns.dirname(doc.fileName);
 
-    if (processedMatches.indexOf(match[1].toLowerCase())) {
+			const path = pathns.resolve(currentDirectory, match[1]);
 
-      // Directory for the current doc
-      const currentDirectory = pathns.dirname(doc.fileName);
-
-      const path = pathns.resolve(currentDirectory, match[1]);
-
-      if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
-
-        localIncludes.push([
-          `Import Statement ${match[1]}`,
-          new IncludeFile(path)
-        ]);
-
-      }
-      else if (fs.existsSync(`${path }.vbs`) && fs.statSync(`${path }.vbs`)?.isFile()) {
-
-        localIncludes.push([
-          `Import Statement ${match[1]}`,
-          new IncludeFile(`${path}.vbs`)
-        ]);
-
-      }
-
-      processedMatches.push(match[1].toLowerCase());
-    }
-  }
-
-  // Loop through each virtual included file
-  while ((match = virtualInclude.exec(doc.getText())) !== null) {
-
-    if (processedMatches.indexOf(match[1].toLowerCase())) {
-
-			const virtualIncludePath = match[1].startsWith(pathns.sep) ? match[1] : `${pathns.sep}${match[1]}`;
-			const docPath = pathns.dirname(doc.uri.path);
-			const directories = docPath.split(pathns.sep);
-
-			while (directories.length != 0) {
-				const path = pathns.normalize(`${directories.join(pathns.sep)}${virtualIncludePath}`);
-
-				if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
-
-					localIncludes.push([
-						`Import Statement ${virtualIncludePath}`,
-						new IncludeFile(path)
-					]);
-					break;
-
-				} else if (fs.existsSync(`${path }.vbs`) && fs.statSync(`${path }.vbs`)?.isFile()) {
-
-					localIncludes.push([
-						`Import Statement ${virtualIncludePath}`,
-						new IncludeFile(`${path}.vbs`)
-					]);
-					break;
-
-				}
-
-				directories.pop();
+			if (checkFileExistence(path)) {
+				localIncludes.push([
+					`Import Statement ${match[1]}`,
+					new IncludeFile(path),
+				]);
 			}
 
-      processedMatches.push(virtualIncludePath.toLowerCase());
-    }
-  }
+			processedMatches.push(match[1].toLowerCase());
+		}
+	}
 
-  return localIncludes;
+	// Loop through each virtual included file
+	while ((match = virtualInclude.exec(doc.getText())) !== null) {
+		if (processedMatches.indexOf(match[1].toLowerCase())) {
+			// Virtual file include path with added leading path separator if not present
+			const virtualIncludePath = match[1].startsWith(pathns.sep)
+				? match[1]
+				: `${pathns.sep}${match[1]}`;
+			// Virtual file full directory
+			const docDirectory = pathns.dirname(doc.uri.path);
+			// Split directory into levels
+			const directoryLevels = docDirectory.split(pathns.sep);
+
+			// Iterate through directory levels until top level reached
+			while (directoryLevels.length > 1) {
+				// Construct file path on current level
+				const path = pathns.normalize(
+					`${directoryLevels.join(pathns.sep)}${virtualIncludePath}`
+				);
+
+				// Check if file exists. If exists, add to `localIncludes` and break out of iteration
+				if (checkFileExistence(path)) {
+					localIncludes.push([
+						`Import Statement ${virtualIncludePath}`,
+						new IncludeFile(path),
+					]);
+
+					break;
+				}
+
+				directoryLevels.pop();
+			}
+
+			// Log error if top level reached and file was not found
+			if (directoryLevels.length <= 1)
+				output.appendLine(
+					`Warning: Unable to resolve virtual file '${virtualIncludePath}'`
+				);
+
+			processedMatches.push(virtualIncludePath.toLowerCase());
+		}
+	}
+
+	return localIncludes;
+}
+
+function checkFileExistence(path: string): boolean {
+	try {
+		if (fs.existsSync(path) && fs.statSync(path)?.isFile()) return true;
+		if (fs.existsSync(`${path}.vbs`) && fs.statSync(`${path}.vbs`)?.isFile())
+			return true;
+	} catch (error) {
+		output.appendLine(`Error: ${error}`);
+	}
+
+	return false;
 }

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -68,12 +68,12 @@ export function getImportedFiles(doc: TextDocument) : [string, IncludeFile][] {
 
     if (processedMatches.indexOf(match[1].toLowerCase())) {
 
-			const virtualIncludePath = match[1].startsWith(pathns.sep) ? match[1] : `/${match[1]}`;
+			const virtualIncludePath = match[1].startsWith(pathns.sep) ? match[1] : `${pathns.sep}${match[1]}`;
 			const docPath = pathns.dirname(doc.uri.path);
 			const directories = docPath.split(pathns.sep);
 
 			while (directories.length != 0) {
-				const path = pathns.normalize(`/${directories.join(pathns.sep)}${virtualIncludePath}`);
+				const path = pathns.normalize(`${directories.join(pathns.sep)}${virtualIncludePath}`);
 
 				if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
 

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -3,102 +3,100 @@ import * as pathns from "path";
 import * as fs from "fs";
 
 export class IncludeFile {
-  constructor(path: string) {
-    let path2 = path;
-    if (!pathns.isAbsolute(path2))
-      path2 = pathns.join(workspace.workspaceFolders[0].uri.fsPath, path2);
+	constructor(path: string) {
+		let path2 = path;
+		if (!pathns.isAbsolute(path2))
+			path2 = pathns.join(workspace.workspaceFolders[0].uri.fsPath, path2);
 
-    this.Uri = Uri.file(path2);
+		this.Uri = Uri.file(path2);
 
-    if (fs.existsSync(path2) && fs.statSync(path2).isFile())
-      this.Content = fs.readFileSync(path2).toString();
-  }
+		if (fs.existsSync(path2) && fs.statSync(path2).isFile())
+			this.Content = fs.readFileSync(path2).toString();
+	}
 
-  Content = "";
+	Content = "";
 
-  Uri: Uri;
+	Uri: Uri;
 }
 
 export const includes = new Map<string, IncludeFile>();
 
-/** Matches `<!-- #include file="myfile.asp" --> */
-export const includePattern = /<!--\s*#include\s*file="(.*?)"\s*-->/ig
-export const virtualInclude = /<!--\s*#include\s*virtual="(.*?)"\s*-->/ig
+/** Matches `<!-- #include file="myfile.asp" --> , `<!-- #include virtual="virtual-folder/myfile.asp" -->`*/
+export const includePattern =
+	/<!--(\s+)?#include(\s+)?(?<type>virtual|file)(\s+)?=(\s+)?\"(?<filename>.*?)\"(\s+)?-->/gis;
+// export const virtualInclude = /<!--\s*#include\s*virtual="(.*?)"\s*-->/ig
 
 /** Gets any included files in the given document. */
-export function getImportedFiles(doc: TextDocument) : [string, IncludeFile][] {
-  const localIncludes = [];
-  const processedMatches = Array<string>();
+export function getImportedFiles(doc: TextDocument): [string, IncludeFile][] {
+	const localIncludes = [];
+	const processedMatches = Array<string>();
 
-  let match : RegExpExecArray;
+	let match: RegExpExecArray;
 
-  // Loop through each included file
-  while ((match = includePattern.exec(doc.getText())) !== null) {
+	// Loop through each included file
+	while ((match = includePattern.exec(doc.getText())) !== null) {
+		if (processedMatches.indexOf(match.groups?.filename.toLowerCase())) {
+			// Directory for the current doc
+			const currentDirectory = pathns.dirname(doc.fileName);
 
-    if (processedMatches.indexOf(match[1].toLowerCase())) {
+			// Handle include types
+			if (match.groups?.type === "file") {
+				// Handle `file` include type. Relative to current doc
 
-      // Directory for the current doc
-      const currentDirectory = pathns.dirname(doc.fileName);
+				const filePath = pathns.resolve(
+					currentDirectory,
+					match.groups?.filename
+				);
 
-      const path = pathns.resolve(currentDirectory, match[1]);
-
-      if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
-
-        localIncludes.push([
-          `Import Statement ${match[1]}`,
-          new IncludeFile(path)
-        ]);
-
-      }
-      else if (fs.existsSync(`${path }.vbs`) && fs.statSync(`${path }.vbs`)?.isFile()) {
-
-        localIncludes.push([
-          `Import Statement ${match[1]}`,
-          new IncludeFile(`${path}.vbs`)
-        ]);
-
-      }
-
-      processedMatches.push(match[1].toLowerCase());
-    }
-  }
-
-  // Loop through each virtual included file
-  while ((match = virtualInclude.exec(doc.getText())) !== null) {
-
-    if (processedMatches.indexOf(match[1].toLowerCase())) {
-
-			const virtualIncludePath = match[1].startsWith(pathns.sep) ? match[1] : `${pathns.sep}${match[1]}`;
-			const docPath = pathns.dirname(doc.uri.path);
-			const directories = docPath.split(pathns.sep);
-
-			while (directories.length != 0) {
-				const path = pathns.normalize(`${directories.join(pathns.sep)}${virtualIncludePath}`);
-
-				if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
-
+				if (checkFileExistence(filePath)) {
 					localIncludes.push([
-						`Import Statement ${virtualIncludePath}`,
-						new IncludeFile(path)
+						`Import Statement ${match.groups?.filename}`,
+						new IncludeFile(filePath),
 					]);
-					break;
-
-				} else if (fs.existsSync(`${path }.vbs`) && fs.statSync(`${path }.vbs`)?.isFile()) {
-
-					localIncludes.push([
-						`Import Statement ${virtualIncludePath}`,
-						new IncludeFile(`${path}.vbs`)
-					]);
-					break;
-
 				}
+			} else {
+				// Handle `virtual` include type. Determine absolute path by scanning through directory levels
 
-				directories.pop();
+				const virtualIncludePath = match.groups?.filename.startsWith(pathns.sep)
+					? match.groups?.filename
+					: `${pathns.sep}${match.groups?.filename}`;
+				const directory = pathns.dirname(doc.uri.path);
+				const directoryLevels = directory.split(pathns.sep);
+
+				// Iterate through directory levels until top level is reached
+				while (directoryLevels.length > 1) {
+					// Construct path from current level
+					const virtualPath = pathns.normalize(
+						`${directoryLevels.join(pathns.sep)}${virtualIncludePath}`
+					);
+
+					// Check for file existence. If found add to `localIncludes` and break out of process
+					if (checkFileExistence(virtualPath)) {
+						localIncludes.push([
+							`Import Statement ${virtualIncludePath}`,
+							new IncludeFile(virtualPath),
+						]);
+
+						break;
+					}
+
+					// Remove the depest level then continue next iteration
+					directoryLevels.pop();
+				}
 			}
 
-      processedMatches.push(virtualIncludePath.toLowerCase());
-    }
-  }
+			processedMatches.push(match.groups?.filename.toLowerCase());
+		}
+	}
 
-  return localIncludes;
+	return localIncludes;
+}
+
+// Checks is include file exists
+function checkFileExistence(path: string): boolean {
+	if (fs.existsSync(path) && fs.statSync(path)?.isFile()) return true;
+	if (fs.existsSync(`${path}.vbs`) && fs.statSync(`${path}.vbs`)?.isFile())
+		return true;
+
+	return false;
 }

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -68,12 +68,12 @@ export function getImportedFiles(doc: TextDocument) : [string, IncludeFile][] {
 
     if (processedMatches.indexOf(match[1].toLowerCase())) {
 
-			const virtualIncludePath = match[1].startsWith('/') ? match[1] : `/${match[1]}`;
+			const virtualIncludePath = match[1].startsWith(pathns.sep) ? match[1] : `/${match[1]}`;
 			const docPath = pathns.dirname(doc.uri.path);
-			const directories = docPath.split('/');
+			const directories = docPath.split(pathns.sep);
 
 			while (directories.length != 0) {
-				const path = pathns.normalize(`/${directories.join('/')}${virtualIncludePath}`);
+				const path = pathns.normalize(`/${directories.join(pathns.sep)}${virtualIncludePath}`);
 
 				if (fs.existsSync(path) && fs.statSync(path)?.isFile()) {
 


### PR DESCRIPTION
Stumbled upon this excellent extension after years of frustration working with ASP code. This is a great one, thank you contributors for all the effort. This one issue was becoming a dealbreaker so decided to give it a go. Feel free to suggest any improvements or things I may have missed

### Descripton

This PR improves upon include file processing logic

- Removes `virtualPath` config dependency
- Updates virtual include processing logic
- Resolves  #6 
- Resolves #25 

### Test Instructions

_Tested on Ubuntu 23.10 running on WSL2_

1. Enter debugging mode (press F5)
2. Create ASP files in various directory levels
3. Include files from step 2 into `index.asp`
4. Intellisense should work
5. Check `Output > ASP Classic` channel for error logs if any